### PR TITLE
Added ability to enter partial hours without leading 0

### DIFF
--- a/lib/aika/timesheets/timesheets.ex
+++ b/lib/aika/timesheets/timesheets.ex
@@ -32,6 +32,7 @@ defmodule Aika.Timesheets do
     |> Timex.to_date()
   end
 
+  defp parse_time("." <> time), do: parse_time("0." <> time)
   defp parse_time(time) when is_binary(time) do
     case String.contains?(time, ".") do
       true -> parse_time(String.to_float(time))


### PR DESCRIPTION
This allows entry of hours without leading 0 such as .25 for 0.25.

Resolves #3 