### PR TITLE
Added org settings page and target hours

### DIFF
--- a/lib/aika/accounts/management.ex
+++ b/lib/aika/accounts/management.ex
@@ -1,0 +1,12 @@
+defmodule Aika.Accounts.Management do
+
+  alias Aika.Accounts.Organisation
+  alias Aika.{Repo, Duration}
+
+  def update_organisation(org, %{"target_hours" => target_hours}) do
+    org
+    |> Organisation.changeset(%{ target_hours: Duration.hours_to_minutes(target_hours)})
+    |> Repo.update
+  end
+
+end

--- a/lib/aika/accounts/organisation.ex
+++ b/lib/aika/accounts/organisation.ex
@@ -5,6 +5,7 @@ defmodule Aika.Accounts.Organisation do
 
   schema "organisations" do
     field :name, :string
+    field :target_hours, :integer
 
     has_many :users, Aika.Accounts.User
 
@@ -15,7 +16,8 @@ defmodule Aika.Accounts.Organisation do
   def changeset(attrs), do: changeset(%Organisation{}, attrs)
   def changeset(%Organisation{} = organisation, attrs) do
     organisation
-    |> cast(attrs, [:name])
-    |> validate_required([:name])
+    |> cast(attrs, [:name, :target_hours])
+    |> validate_required([:name, :target_hours])
   end
+
 end

--- a/lib/aika/duration.ex
+++ b/lib/aika/duration.ex
@@ -1,0 +1,12 @@
+defmodule Aika.Duration do
+
+  def hours_to_minutes("." <> time), do: hours_to_minutes("0." <> time)
+  def hours_to_minutes(time) when is_binary(time) do
+    case String.contains?(time, ".") do
+      true -> hours_to_minutes(String.to_float(time))
+      false -> hours_to_minutes(String.to_integer(time))
+    end
+  end
+  def hours_to_minutes(number), do: round(number * 60)
+
+end

--- a/lib/aika/timesheets/timesheets.ex
+++ b/lib/aika/timesheets/timesheets.ex
@@ -1,5 +1,5 @@
 defmodule Aika.Timesheets do
-  alias Aika.Repo
+  alias Aika.{Repo, Duration}
   alias Aika.Timesheets.{TimeEntry, Queries}
 
   def create(user, date, description, time) do
@@ -7,7 +7,7 @@ defmodule Aika.Timesheets do
       user: user,
       date: parse_date(date),
       description: description,
-      duration: parse_time(time)
+      duration: Duration.hours_to_minutes(time)
     }) |> Repo.insert!
   end
 
@@ -31,15 +31,5 @@ defmodule Aika.Timesheets do
     |> Timex.parse!("%F", :strftime)
     |> Timex.to_date()
   end
-
-  defp parse_time("." <> time), do: parse_time("0." <> time)
-  defp parse_time(time) when is_binary(time) do
-    case String.contains?(time, ".") do
-      true -> parse_time(String.to_float(time))
-      false -> parse_time(String.to_integer(time))
-    end
-  end
-
-  defp parse_time(number), do: round(number * 60)
 
 end

--- a/lib/aika_web/controllers/organisation_controller.ex
+++ b/lib/aika_web/controllers/organisation_controller.ex
@@ -1,0 +1,27 @@
+defmodule AikaWeb.OrganisationController do
+  use AikaWeb, :controller
+
+  alias Aika.Accounts.Management
+
+  def edit(conn, _) do
+    org = conn.assigns[:user].organisation
+    changeset = Ecto.Changeset.change(org)
+    render conn, org: org, changeset: changeset
+  end
+
+  def update(conn, %{"organisation" => org_attrs}) do
+    org = conn.assigns[:user].organisation
+
+    case Management.update_organisation(org, org_attrs) do
+      {:ok, _} ->
+        conn
+        |> put_flash(:info, "Settings updated")
+        |> redirect(to: organisation_path(conn, :edit))
+      {:error, changeset} ->
+        conn
+        |> put_flash(:error, "Error updating settings")
+        |> render "edit.html", org: org, changeset: changeset
+    end
+  end
+
+end

--- a/lib/aika_web/router.ex
+++ b/lib/aika_web/router.ex
@@ -47,6 +47,9 @@ defmodule AikaWeb.Router do
     delete "/users/:id", UserController, :delete
     get "/users/:id", UserController, :show
     post "/users/:id/set_admin", UserController, :set_admin
+
+    get "/organisation/edit", OrganisationController, :edit
+    resources "/organisation", OrganisationController, only: [:update]
   end
 
   # Other scopes may use custom stacks.

--- a/lib/aika_web/templates/organisation/edit.html.eex
+++ b/lib/aika_web/templates/organisation/edit.html.eex
@@ -1,0 +1,11 @@
+<h3>Settings for <%= @org.name %></h3>
+
+<%= form_for @changeset, organisation_path(@conn, :update, @org), fn f -> %>
+
+  <div class="form-group">
+    <%= label f, :target_hours, "Target daily hours" %>
+    <%= text_input f, :target_hours, class: "form-control", value: formatted_target_hours(@org) %>
+  </div>
+
+  <%= submit "Save", class: "btn btn-outline-success" %>
+<% end %>

--- a/lib/aika_web/templates/shared/admin_nav.html.eex
+++ b/lib/aika_web/templates/shared/admin_nav.html.eex
@@ -1,0 +1,6 @@
+<li class="nav-item">
+  <%= link "Users", to: user_path(@conn, :index), class: "nav-link" %>
+</li>
+<li class="nav-item">
+  <%= link "Settings", to: organisation_path(@conn, :edit), class: "nav-link" %>
+</li>

--- a/lib/aika_web/templates/shared/login_nav.html.eex
+++ b/lib/aika_web/templates/shared/login_nav.html.eex
@@ -4,9 +4,7 @@
   </li>
 
   <%= if admin?(@conn) do %>
-    <li class="nav-item">
-      <%= link "Manage Users", to: user_path(@conn, :index), class: "nav-link" %>
-    </li>
+    <%= render AikaWeb.SharedView, "admin_nav.html", conn: @conn %>
   <% end %>
 
 </ul>

--- a/lib/aika_web/views/organisation_view.ex
+++ b/lib/aika_web/views/organisation_view.ex
@@ -1,0 +1,8 @@
+defmodule AikaWeb.OrganisationView do
+  use AikaWeb, :view
+
+  def formatted_target_hours(org) do
+    AikaWeb.DashboardView.formatted_duration(org.target_hours)
+  end
+
+end

--- a/priv/repo/migrations/20171102221406_add_target_hours_to_organisation.exs
+++ b/priv/repo/migrations/20171102221406_add_target_hours_to_organisation.exs
@@ -1,0 +1,9 @@
+defmodule Aika.Repo.Migrations.AddTargetHoursToOrganisation do
+  use Ecto.Migration
+
+  def change do
+    alter table(:organisations) do
+      add :target_hours, :integer, null: false, default: 450
+    end
+  end
+end


### PR DESCRIPTION
This PR adds:

- Page for managing organisations settings, only accessible by the admin users

- Target daily hours in the org settings. This can be used to determine what % of time each user has logged in the upcoming week overview screen