### PR TITLE
remove target_hours from organisation validation

### DIFF
--- a/lib/aika/accounts/organisation.ex
+++ b/lib/aika/accounts/organisation.ex
@@ -17,7 +17,7 @@ defmodule Aika.Accounts.Organisation do
   def changeset(%Organisation{} = organisation, attrs) do
     organisation
     |> cast(attrs, [:name, :target_hours])
-    |> validate_required([:name, :target_hours])
+    |> validate_required([:name])
   end
 
 end

--- a/lib/aika/accounts/user.ex
+++ b/lib/aika/accounts/user.ex
@@ -22,7 +22,7 @@ defmodule Aika.Accounts.User do
     user
     |> cast(attrs, [:email, :role, :password, :token])
     |> validate_required([:email, :password, :role])
-    |> validate_format(:email, ~r/^[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,4}$/)
+    |> validate_format(:email, ~r/@/)
     |> validate_length(:password, min: 8)
     |> hash_password()
     |> put_assoc(:organisation, attrs.organisation)

--- a/lib/aika/accounts/user.ex
+++ b/lib/aika/accounts/user.ex
@@ -22,7 +22,7 @@ defmodule Aika.Accounts.User do
     user
     |> cast(attrs, [:email, :role, :password, :token])
     |> validate_required([:email, :password, :role])
-    |> validate_format(:email, ~r/@/)
+    |> validate_format(:email, ~r/^[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,4}$/)
     |> validate_length(:password, min: 8)
     |> hash_password()
     |> put_assoc(:organisation, attrs.organisation)


### PR DESCRIPTION
My first attempt to sign up an account failed. 
The reason being there is a required validation on target_hours attribute in Organisation.

## Fixes
1. Removed the `target_hours` attribute from Organisation.
2. Changed the regex for email registration.