### PR TITLE
Show weekly hours on dashboard

### DIFF
--- a/assets/css/_tracker.scss
+++ b/assets/css/_tracker.scss
@@ -1,0 +1,56 @@
+$a-tags: 'a, a:active, a:hover, a:visited';
+
+[v-cloak] {
+  display: none;
+}
+
+.tracker-container {
+  display: flex;
+  justify-content: space-between;
+  flex-wrap: wrap;
+  padding-bottom: 1em;
+
+  .week-number {
+    position: relative;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    font-size: 11px;
+    border: 1px solid #ccc;
+    width: 20px;
+    height: 20px;
+    border-radius: 4px;
+    &:hover {
+      cursor: pointer;
+    }
+
+    &.empty {
+      background-color: #f8d7da;
+      color: #721c24;
+    }
+    &.incomplete {
+      background-color: #fff3cd;
+      color: #856404;
+    }
+    &.complete {
+      background-color: #d4edda;
+      color: #155724;
+    }
+    &.active {
+      border: 2px solid $brand-colour;
+    }
+
+    #{$a-tags} {
+      color: inherit;
+      text-decoration: none;
+    }
+  }
+
+  .current-week {
+    position: absolute;
+    bottom: -5px;
+    width: 16px;
+    height: 2px;
+    background-color: $brand-colour;
+  }
+}

--- a/assets/css/app.scss
+++ b/assets/css/app.scss
@@ -1,4 +1,5 @@
 @import 'colours';
+@import 'tracker';
 
 .main-container {
   margin-top: 1em;

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -1,2 +1,3 @@
 import "phoenix_html";
 import "../css/app.scss";
+import "./week-tracker";

--- a/assets/js/helpers/url_parse.js
+++ b/assets/js/helpers/url_parse.js
@@ -1,0 +1,14 @@
+const urlParams = () => {
+  const urlSearch = window.location.search;
+  const hashes = urlSearch.slice(urlSearch.indexOf('?') + 1).split('&');
+  const params = {};
+
+  hashes.map(hash => {
+    let [key, val] = hash.split('=');
+    params[key] = decodeURIComponent(val);
+  });
+
+  return params;
+};
+
+export default urlParams;

--- a/assets/js/week-tracker.js
+++ b/assets/js/week-tracker.js
@@ -1,0 +1,64 @@
+import Vue from 'vue';
+import axios from 'axios';
+import moment from 'moment';
+
+const app = new Vue({
+  el: '#trackerContainer',
+  data: {
+    weeklyHours: {}
+  },
+
+  created() {
+    this.getWeekly();
+  },
+
+  computed: {
+    displayedWeek() {
+      const urlDate = window.location.search.split('=')[1];
+
+      if (urlDate === undefined) {
+        return moment().week();
+      } else {
+        return moment(urlDate).week();
+      }
+    },
+    currentWeek() {
+      return moment().week();
+    }
+  },
+
+  methods: {
+    getWeekly() {
+      axios.get('/entries/weekly')
+        .then(response => {
+          this.weeklyHours = response.data;
+        });
+    },
+
+    padNumber(number) {
+      return number < 10 ? `0${number}` : number;
+    },
+
+    getDate(weekNum) {
+      return moment().day('Monday').week(weekNum).format('YYYY-MM-DD');
+    },
+
+    generateUrl(weekNum) {
+      const date = this.getDate(weekNum);
+      return `/dashboard?date=${date}`;
+    },
+
+    getCssClasses(weekNum) {
+      const hours = this.weeklyHours.weeks[weekNum] || 0;
+      const target = this.weeklyHours.target * 5;
+      const notFuture = weekNum <= this.currentWeek;
+
+      return {
+        'empty': hours === 0 && notFuture,
+        'incomplete': hours > 0 && hours < target,
+        'complete': hours > target,
+        'active': weekNum === this.displayedWeek
+      };
+    }
+  }
+});

--- a/assets/js/week-tracker.js
+++ b/assets/js/week-tracker.js
@@ -1,6 +1,7 @@
 import Vue from 'vue';
 import axios from 'axios';
 import moment from 'moment';
+import urlParams from './helpers/url_parse';
 
 const app = new Vue({
   el: '#trackerContainer',
@@ -14,12 +15,12 @@ const app = new Vue({
 
   computed: {
     displayedWeek() {
-      const urlDate = window.location.search.split('=')[1];
+      const date = urlParams().date;
 
-      if (urlDate === undefined) {
+      if (date === undefined) {
         return moment().week();
       } else {
-        return moment(urlDate).week();
+        return moment(date).week();
       }
     },
     currentWeek() {

--- a/assets/package.json
+++ b/assets/package.json
@@ -6,8 +6,11 @@
     "watch": "node_modules/.bin/webpack --watch --colors --config webpack.dev.js"
   },
   "dependencies": {
+    "axios": "^0.17.1",
+    "moment": "^2.20.1",
     "phoenix": "file:../deps/phoenix",
-    "phoenix_html": "file:../deps/phoenix_html"
+    "phoenix_html": "file:../deps/phoenix_html",
+    "vue": "^2.5.13"
   },
   "devDependencies": {
     "babel-core": "^6.26.0",

--- a/assets/webpack.common.js
+++ b/assets/webpack.common.js
@@ -49,7 +49,11 @@ module.exports = {
   },
 
   resolve: {
-    modules: ["node_modules", __dirname + "/web/static/js"]
+    modules: ["node_modules", __dirname + "/web/static/js"],
+
+    alias: {
+      'vue$': 'vue/dist/vue.esm.js'
+    }
   },
 
   plugins: [

--- a/assets/webpack.prod.js
+++ b/assets/webpack.prod.js
@@ -14,6 +14,11 @@ module.exports = Merge(Common, {
       asset: "[path].gz[query]",
       algorithm: "gzip",
       test: /\.(js|html|css)$/
+    }),
+    new Webpack.DefinePlugin({
+      'process.env': {
+        NODE_ENV: '"production"'
+      }
     })
   ]
 });

--- a/lib/aika_web/templates/dashboard/index.html.eex
+++ b/lib/aika_web/templates/dashboard/index.html.eex
@@ -1,3 +1,17 @@
+<div id="trackerContainer" class="tracker-container" v-if="weeklyHours.weeks">
+
+    <div class="week-number" v-for="weekNum in 52" :class="getCssClasses(weekNum)">
+
+      <a :href="generateUrl(weekNum)" v-cloak>
+        {{ padNumber(weekNum) }}
+      </a>
+
+      <div class="current-week" v-if="weekNum === currentWeek"></div>
+
+    </div>
+
+</div>
+
 <h3>
   <%= link "<", to: dashboard_path(@conn, :index, date: previous_week(@date)) %>
   <%= week_title(@date) %>

--- a/lib/aika_web/views/dashboard_view.ex
+++ b/lib/aika_web/views/dashboard_view.ex
@@ -38,7 +38,10 @@ defmodule AikaWeb.DashboardView do
   end
 
   def formatted_duration(time) do
-    time / 60
+    (time / 60)
+    |> Decimal.new
+    |> Decimal.round(2)
+    |> Decimal.to_float
   end
 
   def week_title(date) do


### PR DESCRIPTION
This PR adds a header row to the dashboard view:

![screen shot 2018-01-11 at 17 40 05](https://user-images.githubusercontent.com/2856248/34838580-7d79e5b0-f6f6-11e7-8264-cf522dfd221e.png)

Implemented in Vue.js, this could easily be converted to React or Elm if someone wanted to.

White squares: future weeks
Green squares: completed weeks
Orange squares: partially completed weeks
Red squares: Not started (and in the past) weeks

- Small indicators highlight both current week (underline) and currently visible week (outline).
- Clicking on a square takes you directly to that week.

One small improvement that could be made...if the 'current week number' could be included in the api response, then I wouldn't need to work it out from the URL.

Let me know if any changes are required 😄 